### PR TITLE
fix(utils): Adds reference to relevant year 2 IDs

### DIFF
--- a/src/utils/courses.json
+++ b/src/utils/courses.json
@@ -3,7 +3,7 @@
     {
       "id": 1,
       "name": "Computer Science",
-      "moduleIDs": [1, 16]
+      "moduleIDs": [1, 2, 3, 4, 5, 6, 7, 8]
     },
     {
       "id": 2,
@@ -13,17 +13,17 @@
     {
       "id": 3,
       "name": "Games Production",
-      "moduleIDs": [1]
+      "moduleIDs": [1, 2, 3, 4, 5, 6, 7, 8]
     },
     {
       "id": 4,
       "name": "Digital Forensics",
-      "moduleIDs": [1]
+      "moduleIDs": [1, 2, 3, 4, 5, 6, 7, 8]
     },
     {
       "id": 5,
       "name": "Cyber Security",
-      "moduleIDs": [1]
+      "moduleIDs": [1, 2, 3, 4, 5, 6, 7, 8]
     }
   ]
 }


### PR DESCRIPTION
As stated above, this references relevant year 2 IDs. I'm not totally sure if these are accurate, but a bug fix would resolve that.